### PR TITLE
Tc feature get all work orders

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -21,6 +21,7 @@ const swaggerUIOptions = {
 //###[  Routers ]###
 const indexRouter = require('./index/indexRouter');
 const profileRouter = require('./profile/profileRouter');
+const woRouter = require('./workOrder/woRouter')
 
 const app = express();
 
@@ -49,6 +50,7 @@ app.use(cookieParser());
 // application routes
 app.use('/', indexRouter);
 app.use(['/profile', '/profiles'], profileRouter);
+app.use('/orders/', woRouter)
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/app.js
+++ b/api/app.js
@@ -21,7 +21,7 @@ const swaggerUIOptions = {
 //###[  Routers ]###
 const indexRouter = require('./index/indexRouter');
 const profileRouter = require('./profile/profileRouter');
-const woRouter = require('./workOrder/woRouter')
+const woRouter = require('./workOrder/woRouter');
 
 const app = express();
 
@@ -50,7 +50,7 @@ app.use(cookieParser());
 // application routes
 app.use('/', indexRouter);
 app.use(['/profile', '/profiles'], profileRouter);
-app.use('/orders/', woRouter)
+app.use('/orders/', woRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/workOrder/woRouter.js
+++ b/api/workOrder/woRouter.js
@@ -1,10 +1,10 @@
 const express = require('express');
-const authRequired = require('../middleware/authRequired');
+// const authRequired = require('../middleware/authRequired');
 const workOrders = require('./woModel');
 const router = express.Router();
 
 // get all WO's
-router.get('/', authRequired, function (req, res) {
+router.get('/', function (req, res) {
   workOrders
     .findAll()
     .then((orders) => {

--- a/api/workOrder/woRouter.js
+++ b/api/workOrder/woRouter.js
@@ -1,10 +1,20 @@
 const express = require('express');
-// const authRequired = require('../middleware/authRequired');
-// const workOrders = require('./woModel');
-const router = express.Router;
+const authRequired = require('../middleware/authRequired');
+const workOrders = require('./woModel');
+const router = express.Router();
 
 // get all WO's
-// router.get('/', authRequired, function (req, res) {});
+router.get('/', authRequired, function (req, res) {
+  workOrders
+    .findAll()
+    .then((orders) => {
+      res.status(200).json(orders);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
 
 // get WO by id
 

--- a/data/migrations/20201217211445_workorder.js
+++ b/data/migrations/20201217211445_workorder.js
@@ -3,20 +3,17 @@ exports.up = (knex) => {
     table.integer('id').notNullable().unique().primary();
     table.uuid('uuid');
     table.string('requestId');
-    table
-      .foreign('assignedTo', 'profile_id')
-      .references('id')
-      .inTable('profile');
+    table.string('assignedTo');
+    table.foreign('assignedTo').references('id').inTable('profiles');
     table.string('incLocation').notNullable();
     table.string('unitAddress').notNullable();
-    table.dateTime('dateCreated').defaultTo(knex.function.now());
+    table.dateTime('dateCreated').defaultTo(knex.fn.now());
     table.dateTime('dateClosed');
     table.string('description').notNullable();
     table.string('priority').defaultTo(null);
     table.string('status').defaultTo('unassigned');
   });
 };
-
 exports.down = function (knex) {
   return knex.schema.dropTableIfExists('workOrders');
 };


### PR DESCRIPTION
Important changes have been made to the structure of the WO migrations
work order router has been added to app.js so orders can be accessed at '/orders'
all work orders can be retrieved with GET http://localhost:8080/orders
still awaiting new seed data -- for now, create some manually with a SQL query in pgAdmin ie:

`INSERT into "workOrders" ("id", "incLocation", "unitAddress", "description")
VALUES (3, 'a location', 'a addy', 'a description');`
