### PR TITLE
tc- prettier format command fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch:dev": "nodemon",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
-    "format": "npx prettier --write \"**/*.+(js|jsx|json|yml|yaml|css|md)\"",
+    "format": "npx prettier --write ./",
     "knex": "npx knex --knexfile config/knexfile.js",
     "tests": "npx jest",
     "coverage": "CI=true npx jest --coverage --detectOpenHandles --forceExit"


### PR DESCRIPTION
I updated the format script in package.json. Sophia and I both were having errors running the original one with npx. With this, prettier can be run with the command
`npm run format`